### PR TITLE
fix(e2e): increase login redirect timeout for smoke tests

### DIFF
--- a/e2e/fixtures/auth.setup.ts
+++ b/e2e/fixtures/auth.setup.ts
@@ -12,8 +12,8 @@ setup('authenticate as regular user', async ({ page }) => {
   await loginPage.goto();
   await loginPage.login(username, password);
 
-  // Wait for redirect away from login page
-  await expect(page).not.toHaveURL(/\/login/);
+  // Wait for redirect away from login page (longer timeout for slow production servers)
+  await expect(page).not.toHaveURL(/\/login/, { timeout: 30_000 });
 
   await page.context().storageState({ path: USER_FILE });
 });
@@ -26,8 +26,8 @@ setup('authenticate as admin', async ({ page }) => {
   await loginPage.goto();
   await loginPage.login(username, password);
 
-  // Wait for redirect away from login page
-  await expect(page).not.toHaveURL(/\/login/);
+  // Wait for redirect away from login page (longer timeout for slow production servers)
+  await expect(page).not.toHaveURL(/\/login/, { timeout: 30_000 });
 
   await page.context().storageState({ path: ADMIN_FILE });
 });

--- a/e2e/full/task-lifecycle.spec.ts
+++ b/e2e/full/task-lifecycle.spec.ts
@@ -194,7 +194,7 @@ test.describe('Task CRUD Lifecycle', () => {
     // (not the more_vert menu button which is in the header)
     await expect(doneCard.locator('button').last()).toBeVisible({ timeout: 10_000 });
     // Verify COMPLETE button is gone to confirm state transition
-    await expect(doneCard.getByRole('button', { name: 'COMPLETE' })).toBeHidden();
+    await expect(doneCard.getByRole('button', { name: 'COMPLETE' })).toBeHidden({ timeout: 10_000 });
 
     // --- ARCHIVE the task ---
     await doneCard.locator('button').last().click();


### PR DESCRIPTION
## Summary
- Increased login redirect timeout from 5s to 30s in auth setup
- Fixes smoke test failures when production server responds slowly
- Applied to both regular user and admin login assertions

## Test plan
- [ ] Verify smoke tests pass against production after merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)