### PR TITLE
ci: require e2e-tests to pass before deploy-to-lan

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -133,7 +133,7 @@ jobs:
         retention-days: 14
 
   deploy-to-lan:
-    needs: build-and-test
+    needs: [build-and-test, e2e-tests]
     if: github.ref == 'refs/heads/main'
     runs-on: [self-hosted, lan, nginx]
 


### PR DESCRIPTION
## Summary
- Added `e2e-tests` as a dependency for `deploy-to-lan` job
- Ensures deployment only proceeds when both unit tests and E2E tests pass

## Test plan
- [ ] Verify CI workflow graph shows correct dependencies

🤖 Generated with [Claude Code](https://claude.ai/claude-code)